### PR TITLE
Feature: Single Post View + Bug Fixes

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -3,18 +3,53 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import UploadPage from './pages/upload';
 import Layout from './layout';
 import CatalogPage from './pages/catalog';
+import sounds from './lib/sound-catalog.json';
+import AppContext from './lib/app-context';
 
 export default class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.playSound = this.playSound.bind(this);
+    this.sounds = sounds.map(sound => {
+      if (sound.path === '') return null;
+      return new Audio(`res/${sound.path}`);
+    });
+  }
+
+  playSound(index) {
+    this.sounds.forEach(sound => {
+      if (!sound) {
+        return;
+      }
+      sound.pause();
+      sound.currentTime = 0;
+    });
+    if (!this.sounds[index]) {
+      return;
+    }
+    try {
+      this.sounds[index].play();
+    } catch (e) {}
+  }
+
   render() {
+    const context = {
+      state: this.state,
+      setState: this.setState,
+      playSound: this.playSound
+    };
     return (
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<CatalogPage />} />
-            <Route path="upload" element={<UploadPage />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
+      <AppContext.Provider value={context}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<CatalogPage />} />
+              <Route path="upload" element={<UploadPage />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </AppContext.Provider>
     );
   }
 }

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -15,7 +15,7 @@ export default class App extends React.Component {
     this.playSound = this.playSound.bind(this);
     this.sounds = sounds.map(sound => {
       if (sound.path === '') return null;
-      return new Audio(`res/${sound.path}`);
+      return new Audio(`/res/${sound.path}`);
     });
   }
 
@@ -32,7 +32,9 @@ export default class App extends React.Component {
     }
     try {
       this.sounds[index].play();
-    } catch (e) {}
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   render() {

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -5,6 +5,8 @@ import Layout from './layout';
 import CatalogPage from './pages/catalog';
 import sounds from './lib/sound-catalog.json';
 import AppContext from './lib/app-context';
+import SinglePostPage from './pages/single-post';
+import NotFoundPage from './pages/not-found';
 
 export default class App extends React.Component {
   constructor(props) {
@@ -43,9 +45,13 @@ export default class App extends React.Component {
       <AppContext.Provider value={context}>
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<Layout />}>
+            <Route path="*" element={<Layout />}>
               <Route index element={<CatalogPage />} />
               <Route path="upload" element={<UploadPage />} />
+              <Route path="posts">
+                <Route path=":id" element={<SinglePostPage />} />
+              </Route>
+              <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/client/components/header.jsx
+++ b/client/components/header.jsx
@@ -20,8 +20,8 @@ export default function Header(props) {
 
   return (
     <header
-      className="navbar rounded-box sticky
-        top-4 mx-auto mb-8 flex w-11/12 max-w-3xl items-center
+      className="navbar rounded-box sticky top-4
+        mx-auto mb-8 flex w-11/12 max-w-3xl select-none items-center
         justify-center bg-primary px-4 text-primary-content shadow-md">
       <div className="justify-left flex-1 flex-shrink md:flex-none">
         <NavLink
@@ -40,7 +40,7 @@ export default function Header(props) {
       </div>
 
       <div className="flex flex-1 justify-end md:hidden">
-        <div className="dropdown-end dropdown">
+        <div className="dropdown dropdown-end">
           <label tabIndex="0" className="btn btn-primary">
             <span className="material-icons">menu</span>
           </label>

--- a/client/components/header.jsx
+++ b/client/components/header.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavLink, useLocation, Routes, Route } from 'react-router-dom';
+import { NavLink, Routes, Route } from 'react-router-dom';
 
 export default function Header(props) {
   const homeHeader = 'Symbol Art Vault';
@@ -27,7 +27,7 @@ export default function Header(props) {
 
   return (
     <header
-      className="navbar rounded-box sticky top-4
+      className="navbar rounded-box sticky top-4 z-10
         mx-auto mb-8 flex w-11/12 max-w-3xl select-none items-center
         justify-center bg-primary px-4 text-primary-content shadow-md">
       <div className="justify-left flex-1 flex-shrink md:flex-none">

--- a/client/components/header.jsx
+++ b/client/components/header.jsx
@@ -1,22 +1,29 @@
 import React from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation, Routes, Route } from 'react-router-dom';
 
 export default function Header(props) {
-  const { pathname } = useLocation();
-  /**
-   * Key: Path
-   * Header: String to display on Header and Menu
-   */
-  const titles = {
-    '/': {
-      header: 'Symbol Vault'
+  const homeHeader = 'Symbol Art Vault';
+  const paths = [
+    {
+      path: 'upload',
+      header: 'New Post'
     },
-    '/upload': {
+    {
+      path: 'posts/:id',
+      header: 'Viewing Post'
+    },
+    {
+      path: '*',
+      header: '404: Not Found'
+    }
+  ];
+
+  const actions = [
+    {
+      path: 'upload',
       header: 'New Post'
     }
-  };
-
-  const actions = [titles['/upload']];
+  ];
 
   return (
     <header
@@ -35,12 +42,19 @@ export default function Header(props) {
 
       <div className="flex-auto justify-center md:justify-start md:px-4">
         <h1 className="text-center text-4xl font-black leading-none">
-          {titles[pathname].header}
+          <Routes>
+            <Route index element={<>{homeHeader}</>} />
+            {paths.map(e => {
+              return (
+                <Route key={e.path} path={e.path} element={<>{e.header}</>} />
+              );
+            })}
+          </Routes>
         </h1>
       </div>
 
       <div className="flex flex-1 justify-end md:hidden">
-        <div className="dropdown dropdown-end">
+        <div className="dropdown-end dropdown">
           <label tabIndex="0" className="btn btn-primary">
             <span className="material-icons">menu</span>
           </label>
@@ -70,7 +84,7 @@ export default function Header(props) {
           actions.map(action => (
             <NavLink
               key={action}
-              to="upload"
+              to={action.path}
               className={({ isActive }) =>
                 !isActive ? 'btn btn-primary text-xl lowercase' : 'hidden'
               }>

--- a/client/components/placeholder-image.jsx
+++ b/client/components/placeholder-image.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function PlaceholderImage(props) {
+  return (
+    <div className="bg-300 rounded-box aspect-[2/1] w-full animate-pulse"></div>
+  );
+}

--- a/client/components/symbol-art-card.jsx
+++ b/client/components/symbol-art-card.jsx
@@ -47,12 +47,19 @@ export default function SymbolArtCard(props) {
             <span className="material-icons text-xs">description</span>
             {filePropsName}
           </div>
-          <button
-            className="btn btn-outline btn-xs gap-2 rounded-full text-sm font-semibold"
-            onClick={e => playSound(filePropsSound)}>
-            <span className="material-icons text-xs">volume_up</span>
-            {sounds[filePropsSound].name}
-          </button>
+          {
+            // prettier-ignore
+            filePropsSound !== 1
+              ? (
+            <button
+              className="btn btn-outline btn-xs gap-2 rounded-full text-sm font-semibold"
+              onClick={e => playSound(filePropsSound)}>
+              <span className="material-icons text-xs">volume_up</span>
+              {sounds[filePropsSound].name}
+            </button>
+                )
+              : null
+          }{' '}
         </div>
       </div>
       <div>

--- a/client/components/symbol-art-card.jsx
+++ b/client/components/symbol-art-card.jsx
@@ -32,7 +32,7 @@ export default function SymbolArtCard(props) {
 
   const { playSound } = props;
 
-  const downloadLink = `/api/post/${postId}/download`;
+  const downloadLink = `/api/posts/download?id=${postId}`;
 
   return (
     <div className="grid-item rounded-box flex h-fit flex-col gap-4 bg-base-100 p-4">

--- a/client/components/symbol-art-card.jsx
+++ b/client/components/symbol-art-card.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import propTypes from 'prop-types';
 import sounds from '../lib/sound-catalog.json';
+import { urlDownloadFromId } from '../lib/endpoints';
 
 function PlaceholderImage() {
   return (
@@ -32,7 +33,7 @@ export default function SymbolArtCard(props) {
 
   const { playSound } = props;
 
-  const downloadLink = `/api/posts/download?id=${postId}`;
+  const downloadLink = urlDownloadFromId(postId);
 
   return (
     <div className="grid-item rounded-box flex h-fit flex-col gap-4 bg-base-100 p-4">

--- a/client/components/symbol-art-card.jsx
+++ b/client/components/symbol-art-card.jsx
@@ -1,25 +1,12 @@
 import React from 'react';
-import { LazyLoadImage } from 'react-lazy-load-image-component';
 import propTypes from 'prop-types';
-import sounds from '../lib/sound-catalog.json';
-import { apiDownloadPostFromId, urlPostFromId } from '../lib/endpoints';
-import AppContext from '../lib/app-context';
 import { Link } from 'react-router-dom';
-
-function PlaceholderImage() {
-  return (
-    <div className="bg-300 rounded-box aspect-[2/1] w-full animate-pulse"></div>
-  );
-}
-
-function Tag(props) {
-  const { tag } = props;
-  return (
-    <li className="badge badge-ghost overflow-x-clip">
-      <button>{tag}</button>
-    </li>
-  );
-}
+import { LazyLoadImage } from 'react-lazy-load-image-component';
+import { apiDownloadPostFromId, pathPostFromId } from '../lib/endpoints';
+import AppContext from '../lib/app-context';
+import sounds from '../lib/sound-catalog.json';
+import Tag from './tag';
+import PlaceholderImage from './placeholder-image';
 
 /**
  *
@@ -46,18 +33,20 @@ export default function SymbolArtCard(props) {
   } = props.symbolArt;
 
   const downloadLink = apiDownloadPostFromId(postId);
-  const postLink = urlPostFromId(postId);
+  const postLink = pathPostFromId(postId);
 
   return (
     <div className="grid-item rounded-box flex h-fit flex-col gap-4 bg-base-100 p-4">
       <div className="flex flex-col gap-4">
-        <LazyLoadImage
-          className="rounded-box aspect-[2/1] w-full select-none"
-          src={previewImagePath}
-          placeholder={<PlaceholderImage />}
-        />
+        <Link to={postLink} className="transition-all hover:translate-y-0.5">
+          <LazyLoadImage
+            className="rounded-box aspect-[2/1] w-full select-none shadow-sm"
+            src={previewImagePath}
+            placeholder={<PlaceholderImage />}
+          />
+        </Link>
         <div className="flex justify-between">
-          <div className="badge badge-lg badge-ghost gap-2 overflow-x-clip font-semibold">
+          <div className="flex items-center gap-2 break-all rounded-full bg-base-300 px-2 font-semibold">
             <span className="material-icons select-none text-xs">
               description
             </span>
@@ -78,12 +67,12 @@ export default function SymbolArtCard(props) {
           }{' '}
         </div>
       </div>
-      <div>
-        <div>
-          <Link
-            className="link-hover m-0 break-words break-all text-lg font-bold "
-            to={postLink}>
-            {title}
+      <div className="y-2 flex flex-col ">
+        <div className="w-fit">
+          <Link to={postLink}>
+            <h3 className="link-hover m-0 break-words break-all text-lg font-bold">
+              {title}
+            </h3>
           </Link>
         </div>
         <h4 className="text-sm font-semibold">@{username}</h4>

--- a/client/components/symbol-art-card.jsx
+++ b/client/components/symbol-art-card.jsx
@@ -39,13 +39,15 @@ export default function SymbolArtCard(props) {
     <div className="grid-item rounded-box flex h-fit flex-col gap-4 bg-base-100 p-4">
       <div className="flex flex-col gap-4">
         <LazyLoadImage
-          className="rounded-box aspect-[2/1] w-full"
+          className="rounded-box aspect-[2/1] w-full select-none"
           src={previewImagePath}
           placeholder={<PlaceholderImage />}
         />
         <div className="flex justify-between">
           <div className="badge badge-lg badge-ghost gap-2 overflow-x-clip font-semibold">
-            <span className="material-icons text-xs">description</span>
+            <span className="material-icons select-none text-xs">
+              description
+            </span>
             {filePropsName}
           </div>
           {

--- a/client/components/symbol-art-card.jsx
+++ b/client/components/symbol-art-card.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import propTypes from 'prop-types';
 import sounds from '../lib/sound-catalog.json';
-import { urlDownloadFromId } from '../lib/endpoints';
+import { apiDownloadPostFromId, urlPostFromId } from '../lib/endpoints';
+import AppContext from '../lib/app-context';
+import { Link } from 'react-router-dom';
 
 function PlaceholderImage() {
   return (
@@ -19,7 +21,19 @@ function Tag(props) {
   );
 }
 
+/**
+ *
+ * @param {Object} props
+ * @param {Object} props.symbolArt - Symbol Art data from fetch request.
+ * @returns
+ */
 export default function SymbolArtCard(props) {
+  const { playSound } = React.useContext(AppContext);
+
+  if (!props.symbolArt) {
+    return;
+  }
+
   const {
     postId,
     title,
@@ -31,9 +45,8 @@ export default function SymbolArtCard(props) {
     filePropsName
   } = props.symbolArt;
 
-  const { playSound } = props;
-
-  const downloadLink = urlDownloadFromId(postId);
+  const downloadLink = apiDownloadPostFromId(postId);
+  const postLink = urlPostFromId(postId);
 
   return (
     <div className="grid-item rounded-box flex h-fit flex-col gap-4 bg-base-100 p-4">
@@ -67,9 +80,11 @@ export default function SymbolArtCard(props) {
       </div>
       <div>
         <div>
-          <h3 className="m-0 break-words break-all text-lg font-bold ">
+          <Link
+            className="link-hover m-0 break-words break-all text-lg font-bold "
+            to={postLink}>
             {title}
-          </h3>
+          </Link>
         </div>
         <h4 className="text-sm font-semibold">@{username}</h4>
         <p className="text-sm">{description}</p>

--- a/client/components/symbol-art-single-post.jsx
+++ b/client/components/symbol-art-single-post.jsx
@@ -16,7 +16,11 @@ export default function SinglePostSymbolArt(props) {
   const { playSound } = React.useContext(AppContext);
 
   if (!props.symbolArt) {
-    return;
+    return (
+      <div className="alert alert-error justify-center text-3xl font-bold">
+        <h2>Unable to find post with ID ({props.id})</h2>
+      </div>
+    );
   }
 
   const {

--- a/client/components/symbol-art-single-post.jsx
+++ b/client/components/symbol-art-single-post.jsx
@@ -15,7 +15,11 @@ import Tag from './tag';
 export default function SinglePostSymbolArt(props) {
   const { playSound } = React.useContext(AppContext);
 
-  if (!props.symbolArt) {
+  if (props.loading) {
+    return;
+  }
+
+  if (!props.symbolArt && !props.loading) {
     return (
       <div className="alert alert-error justify-center text-3xl font-bold">
         <h2>Unable to find post with ID ({props.id})</h2>

--- a/client/components/symbol-art-single-post.jsx
+++ b/client/components/symbol-art-single-post.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { LazyLoadImage } from 'react-lazy-load-image-component';
+import { apiDownloadPostFromId } from '../lib/endpoints';
+import AppContext from '../lib/app-context';
+import sounds from '../lib/sound-catalog.json';
+import PlaceholderImage from './placeholder-image';
+import Tag from './tag';
+
+/**
+ *
+ * @param {Object} props
+ * @param {Object} props.symbolArt - Symbol Art data from fetch request.
+ * @returns
+ */
+export default function SinglePostSymbolArt(props) {
+  const { playSound } = React.useContext(AppContext);
+
+  if (!props.symbolArt) {
+    return;
+  }
+
+  const {
+    postId,
+    title,
+    description,
+    previewImagePath,
+    tags,
+    username,
+    filePropsSound,
+    filePropsName,
+    filePropsLayerCount
+  } = props.symbolArt;
+
+  const downloadLink = apiDownloadPostFromId(postId);
+
+  const handleShareLink = () => {
+    navigator.clipboard.writeText(window.location.href);
+  };
+
+  return (
+    <div className="grid-item rounded-box mx-auto flex h-fit max-w-2xl flex-col gap-8 bg-base-100 p-4">
+      <div className="flex flex-col gap-4">
+        <LazyLoadImage
+          className="rounded-box aspect-[2/1] w-full select-none"
+          src={previewImagePath}
+          placeholder={<PlaceholderImage />}
+        />
+        <div className="flex justify-between">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 break-all rounded-full bg-base-300 px-4 py-1 text-lg font-semibold">
+              <span className="material-icons text-md select-none">
+                description
+              </span>
+              {filePropsName}
+            </div>
+            <div className="text-md flex w-fit items-center gap-2 break-words rounded-full bg-base-300 px-4 font-semibold">
+              <span className="material-icons text-md select-none">layers</span>
+              {filePropsLayerCount} Layers
+            </div>
+          </div>
+          {
+            // prettier-ignore
+            filePropsSound !== 1
+              ? (
+            <button
+              className="btn btn-outline btn-sm gap-2 rounded-full text-lg font-bold"
+              onClick={e => playSound(filePropsSound)}>
+              <span className="material-icons text-md">volume_up</span>
+              {sounds[filePropsSound].name}
+            </button>
+                )
+              : null
+          }{' '}
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <h3 className="break-words break-all text-4xl font-bold ">{title}</h3>
+        <h4 className="text-xl font-semibold">@{username}</h4>
+        <p className="text-lg">{description}</p>
+      </div>
+      <ul className="flex flex-wrap gap-2">
+        {tags.map((tag, id) => {
+          if (tag === '') return '';
+          return <Tag key={id} tag={tag} />;
+        })}
+      </ul>
+      <div className="grid grid-cols-2 gap-4">
+        <button
+          onClick={handleShareLink}
+          className="btn btn-accent btn-md flex w-full gap-2 px-2 text-xl ">
+          <span className="hidden sm:block">Copy Link</span>
+          <span className="material-icons text-2xl">link</span>
+        </button>
+        <a
+          href={downloadLink}
+          className="btn btn-secondary btn-md w-full items-center gap-2 px-2 text-xl">
+          <span className="hidden sm:block">Download</span>
+          <span className="material-icons text-2xl">file_download</span>
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/client/components/tag.jsx
+++ b/client/components/tag.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Tag(props) {
+  const { tag } = props;
+  return (
+    <li className="badge badge-ghost overflow-x-clip ">
+      <div>{tag}</div>
+    </li>
+  );
+}

--- a/client/components/utils/navigate.jsx
+++ b/client/components/utils/navigate.jsx
@@ -1,0 +1,10 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Navigate(props) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate('/');
+  });
+  return <></>;
+}

--- a/client/components/utils/navigate.jsx
+++ b/client/components/utils/navigate.jsx
@@ -3,8 +3,9 @@ import { useNavigate } from 'react-router-dom';
 
 export default function Navigate(props) {
   const navigate = useNavigate();
+  const { to } = props;
   useEffect(() => {
-    navigate('/');
+    navigate(to);
   });
   return <></>;
 }

--- a/client/lib/app-context.js
+++ b/client/lib/app-context.js
@@ -1,0 +1,3 @@
+import React from 'react';
+const AppContext = React.createContext();
+export default AppContext;

--- a/client/lib/endpoints.js
+++ b/client/lib/endpoints.js
@@ -1,0 +1,8 @@
+/**
+ * Generate URL to download from `/api/posts/download` endpoint.
+ * @param {Number} postId - ID of the post to download.
+ * @returns {String} URL to download. Set this as href of download link.
+ */
+export function urlDownloadFromId(postId) {
+  return `/api/posts/download?id=${postId}`;
+}

--- a/client/lib/endpoints.js
+++ b/client/lib/endpoints.js
@@ -3,6 +3,14 @@
  * @param {Number} postId - ID of the post to download.
  * @returns {String} URL to download. Set this as href of download link.
  */
-export function urlDownloadFromId(postId) {
-  return `/api/posts/download?id=${postId}`;
+export function apiDownloadPostFromId(postId) {
+  return `/api/posts/download/${postId}`;
+}
+
+export function urlPostFromId(postId) {
+  return `/posts/${postId}`;
+}
+
+export function apiViewPostFromId(postId) {
+  return `/api/posts/view/${postId}`;
 }

--- a/client/lib/endpoints.js
+++ b/client/lib/endpoints.js
@@ -7,7 +7,7 @@ export function apiDownloadPostFromId(postId) {
   return `/api/posts/download/${postId}`;
 }
 
-export function urlPostFromId(postId) {
+export function pathPostFromId(postId) {
   return `/posts/${postId}`;
 }
 

--- a/client/pages/catalog.jsx
+++ b/client/pages/catalog.jsx
@@ -23,7 +23,12 @@ export default class CatalogPage extends React.Component {
       sound.pause();
       sound.currentTime = 0;
     });
-    this.sounds[index].play();
+    if (!this.sounds[index]) {
+      return;
+    }
+    try {
+      this.sounds[index].play();
+    } catch (e) {}
   }
 
   componentDidMount() {

--- a/client/pages/catalog.jsx
+++ b/client/pages/catalog.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SymbolArtCard from '../components/symbol-art-card';
-import sounds from '../lib/sound-catalog.json';
+import AppContext from '../lib/app-context';
 
 export default class CatalogPage extends React.Component {
   constructor(props) {
@@ -8,27 +8,6 @@ export default class CatalogPage extends React.Component {
     this.state = {
       currentlyViewing: []
     };
-    this.playSound = this.playSound.bind(this);
-    this.sounds = sounds.map(sound => {
-      if (sound.path === '') return null;
-      return new Audio(`res/${sound.path}`);
-    });
-  }
-
-  playSound(index) {
-    this.sounds.forEach(sound => {
-      if (!sound) {
-        return;
-      }
-      sound.pause();
-      sound.currentTime = 0;
-    });
-    if (!this.sounds[index]) {
-      return;
-    }
-    try {
-      this.sounds[index].play();
-    } catch (e) {}
   }
 
   componentDidMount() {
@@ -48,7 +27,7 @@ export default class CatalogPage extends React.Component {
             <SymbolArtCard
               key={symbolArt.postId}
               symbolArt={symbolArt}
-              playSound={this.playSound}
+              playSound={this.context.playSound}
             />
           );
         })}
@@ -56,3 +35,4 @@ export default class CatalogPage extends React.Component {
     );
   }
 }
+CatalogPage.contextType = AppContext;

--- a/client/pages/catalog.jsx
+++ b/client/pages/catalog.jsx
@@ -23,13 +23,7 @@ export default class CatalogPage extends React.Component {
     return (
       <div className="grid gap-4 sm:grid-cols-2">
         {this.state.currentlyViewing.map(symbolArt => {
-          return (
-            <SymbolArtCard
-              key={symbolArt.postId}
-              symbolArt={symbolArt}
-              playSound={this.context.playSound}
-            />
-          );
+          return <SymbolArtCard key={symbolArt.postId} symbolArt={symbolArt} />;
         })}
       </div>
     );

--- a/client/pages/not-found.jsx
+++ b/client/pages/not-found.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function NotFoundPage() {
+  return (
+    <div>
+      <p className="p-8 text-center text-5xl font-black">
+        OOPSIE WOOPSIE!! 😳 Uwu 😚 We make a dumby wumby!! 🙅‍♂️🤷🏼‍♀️ A wittle bonky
+        boingo! 🌈💫 The code monkeys 🙈🙉at our headquarters 🕍 💤 are working
+        VEWY HAWD 💸💯 to fix this! ♿️
+      </p>
+    </div>
+  );
+}

--- a/client/pages/single-post.jsx
+++ b/client/pages/single-post.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import SymbolArtCard from '../components/symbol-art-card';
+import SinglePostSymbolArt from '../components/symbol-art-single-post';
 import { apiViewPostFromId } from '../lib/endpoints';
 
 export default function SinglePostPage(props) {
@@ -14,5 +14,5 @@ export default function SinglePostPage(props) {
       .then(([symbolArtRes]) => setSymbolArt(symbolArtRes));
   }, [id]);
 
-  return <SymbolArtCard symbolArt={symbolArt} />;
+  return <SinglePostSymbolArt symbolArt={symbolArt} />;
 }

--- a/client/pages/single-post.jsx
+++ b/client/pages/single-post.jsx
@@ -11,8 +11,15 @@ export default function SinglePostPage(props) {
   useEffect(() => {
     fetch(apiPath)
       .then(res => res.json())
-      .then(([symbolArtRes]) => setSymbolArt(symbolArtRes));
+      .then(res => {
+        if (Object.keys(res)[0] === 'error') {
+          setSymbolArt(null);
+        } else {
+          const [symbolArtRes] = res;
+          setSymbolArt(symbolArtRes);
+        }
+      });
   }, [id]);
 
-  return <SinglePostSymbolArt symbolArt={symbolArt} />;
+  return <SinglePostSymbolArt symbolArt={symbolArt} id={id} />;
 }

--- a/client/pages/single-post.jsx
+++ b/client/pages/single-post.jsx
@@ -1,0 +1,16 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import SymbolArtCard from '../components/symbol-art-card';
+import { apiViewPostFromId } from '../lib/endpoints';
+
+export default function SinglePostPage(props) {
+  const { id } = useParams();
+  const apiPath = apiViewPostFromId(id);
+  const [symbolArt, setSymbolArt] = useState();
+
+  fetch(apiPath)
+    .then(res => res.json())
+    .then(([symbolArtRes]) => setSymbolArt(symbolArtRes));
+
+  return <SymbolArtCard symbolArt={symbolArt} />;
+}

--- a/client/pages/single-post.jsx
+++ b/client/pages/single-post.jsx
@@ -8,9 +8,11 @@ export default function SinglePostPage(props) {
   const apiPath = apiViewPostFromId(id);
   const [symbolArt, setSymbolArt] = useState();
 
-  fetch(apiPath)
-    .then(res => res.json())
-    .then(([symbolArtRes]) => setSymbolArt(symbolArtRes));
+  useEffect(() => {
+    fetch(apiPath)
+      .then(res => res.json())
+      .then(([symbolArtRes]) => setSymbolArt(symbolArtRes));
+  }, [id]);
 
   return <SymbolArtCard symbolArt={symbolArt} />;
 }

--- a/client/pages/single-post.jsx
+++ b/client/pages/single-post.jsx
@@ -7,8 +7,10 @@ export default function SinglePostPage(props) {
   const { id } = useParams();
   const apiPath = apiViewPostFromId(id);
   const [symbolArt, setSymbolArt] = useState();
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    setLoading(true);
     fetch(apiPath)
       .then(res => res.json())
       .then(res => {
@@ -18,8 +20,11 @@ export default function SinglePostPage(props) {
           const [symbolArtRes] = res;
           setSymbolArt(symbolArtRes);
         }
+        setLoading(false);
       });
   }, [id]);
 
-  return <SinglePostSymbolArt symbolArt={symbolArt} id={id} />;
+  return (
+    <SinglePostSymbolArt loading={loading} symbolArt={symbolArt} id={id} />
+  );
 }

--- a/client/pages/upload.jsx
+++ b/client/pages/upload.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
+import Navigate from '../components/utils/navigate';
 import SarRenderToPng from '../components/sar-renderer';
 import processSarBuffer from '../lib/sar-parse';
 
@@ -7,14 +7,6 @@ const descriptionCharLimit = 90;
 const titleCharLimit = 25;
 const tagCharLimit = 10;
 const tagCountLimit = 5;
-
-function Navigate(props) {
-  const navigate = useNavigate();
-  useEffect(() => {
-    navigate('/');
-  });
-  return <></>;
-}
 
 export default class UploadPage extends React.Component {
   constructor(props) {
@@ -118,6 +110,9 @@ export default class UploadPage extends React.Component {
   }
 
   fileLoad(file) {
+    if (!file) {
+      return;
+    }
     file
       .arrayBuffer()
       .then(processSarBuffer)

--- a/server/index.js
+++ b/server/index.js
@@ -87,11 +87,11 @@ app.get('/api/catalog/:offset', (req, res, next) => {
 });
 
 /**
- *
- * ? Handles downloads of SAR files given the ID of post.
+ * ? Redirects to a download of the SAR file given the ID of post.
+ * @QueryParam id - ID of the post to download.
  */
-app.get('/api/post/:id/download', (req, res, next) => {
-  const { id } = req.params;
+app.get('/api/posts/download', (req, res, next) => {
+  const { id } = req.query;
   if (Number.isNaN(Number(id))) {
     throw new ClientError(400, 'please provide a valid post ID (number)');
   }

--- a/server/index.js
+++ b/server/index.js
@@ -86,14 +86,9 @@ app.get('/api/catalog/:offset', (req, res, next) => {
 
 /**
  * ? Queries DB for single post and its details, like /api/catalog/ but single.
- * * query:
- * *    id: ID of post to search for
- * * response:
- * *    single row of data for post
- * ? i.e. /api/posts/view?id=420
  */
-app.get('/api/posts/view', (req, res, next) => {
-  const { id } = req.query;
+app.get('/api/posts/view/:id', (req, res, next) => {
+  const { id } = req.params;
   const sql = `/* SQL */
     with "tag_arrays" as (
       select
@@ -126,14 +121,9 @@ app.get('/api/posts/view', (req, res, next) => {
 
 /**
  * ? Redirects to a download of the SAR file given the ID of post.
- * * query:
- * *    id: ID of post to download
- * * response:
- * *    redirect to URL for download.
- * ? i.e. /api/posts/download?id=420
  */
-app.get('/api/posts/download', (req, res, next) => {
-  const { id } = req.query;
+app.get('/api/posts/download/:id', (req, res, next) => {
+  const { id } = req.params;
   if (Number.isNaN(Number(id))) {
     throw new ClientError(400, 'please provide a valid post ID (number)');
   }

--- a/server/index.js
+++ b/server/index.js
@@ -89,6 +89,9 @@ app.get('/api/catalog/:offset', (req, res, next) => {
  */
 app.get('/api/posts/view/:id', (req, res, next) => {
   const { id } = req.params;
+  if (Number.isNaN(Number(id))) {
+    throw new ClientError(400, 'please provide a valid post ID (number)');
+  }
   const sql = `/* SQL */
     with "tag_arrays" as (
       select

--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,6 @@ if (process.env.NODE_ENV === 'development') {
 app.use(express.static(publicPath));
 
 /**
- *
  * ? Get all post data.
  */
 app.get('/api/catalog', (req, res, next) => {
@@ -54,7 +53,6 @@ app.get('/api/catalog', (req, res, next) => {
 });
 
 /**
- *
  * ? Get post data limited with a limit to 20, provided the offset
  */
 app.get('/api/catalog/:offset', (req, res, next) => {
@@ -87,8 +85,52 @@ app.get('/api/catalog/:offset', (req, res, next) => {
 });
 
 /**
+ * ? Queries DB for single post and its details, like /api/catalog/ but single.
+ * * query:
+ * *    id: ID of post to search for
+ * * response:
+ * *    single row of data for post
+ * ? i.e. /api/posts/view?id=420
+ */
+app.get('/api/posts/view', (req, res, next) => {
+  const { id } = req.query;
+  const sql = `/* SQL */
+    with "tag_arrays" as (
+      select
+        "postId",
+        array_agg("tagName") as "tags"
+      from "taggings"
+      group by "postId"
+    )
+
+    select
+      "title", "description", "username",
+      "fileObjectKey", "previewImagePath",
+      "filePropsName", "filePropsSound", "filePropsLayerCount",
+      "postId", "userId", "p"."createdAt", "tags"
+    from "posts" as "p"
+    join "files" using ("fileId")
+    join "users" using ("userId")
+    join "tag_arrays" using ("postId")
+    where "postId" = $1;
+  `;
+  db.query(sql, [id])
+    .then(({ rows }) => {
+      if (!rows[0]) {
+        throw new ClientError(404, `unable to find entry with id: ${id}`);
+      }
+      res.json(rows);
+    })
+    .catch(err => next(err));
+});
+
+/**
  * ? Redirects to a download of the SAR file given the ID of post.
- * @QueryParam id - ID of the post to download.
+ * * query:
+ * *    id: ID of post to download
+ * * response:
+ * *    redirect to URL for download.
+ * ? i.e. /api/posts/download?id=420
  */
 app.get('/api/posts/download', (req, res, next) => {
   const { id } = req.query;
@@ -118,7 +160,6 @@ app.get('/api/posts/download', (req, res, next) => {
 });
 
 /**
- *
  * ? Handle uploads from forms on the path '/api/upload'
  */
 app.post(


### PR DESCRIPTION
# Resolves #4, Fixes #17

## Changes

- Added a new endpoint `/api/posts/view/:id` for grabbing data of a single view
- Sounds are now global via `AppContext`
- Certain elements, such as Header and Icon, can no longer be selected.
- Added `<NotFound />` page for nonexistent routes.
- Created `<SinglePostPage />` and route `/posts/:id` which fetches post data with `id` via `/api/posts/view/:id` endpoint.
	- Added button to copy URL.
	- Handle 404s from posts that don't exist.
- User can navigate to single post view through catalog by clicking on either the preview image or title of a post.
- Removed `cursor: pointer` on tag badges for now.

## Etc.

- Addressed #17 

## Previews

### Navigate from Catalog Page to Single Post Page

![catalog-to-single-post](https://user-images.githubusercontent.com/78003700/171967829-e3298a5f-01af-444b-a7b5-edb30986dcee.gif)

### Route History working as intended

![route-history](https://user-images.githubusercontent.com/78003700/171967840-149469a0-9756-43a3-ac24-a1f4d3a2ac70.gif)
 
### Access Post from URL + 404 check

![route-from-url](https://user-images.githubusercontent.com/78003700/171967850-5d3bfba5-6722-4cfd-b27a-5a3700c1348d.gif)

